### PR TITLE
Updated promtail-auth from data: to stringData:

### DIFF
--- a/secrets/promtail/promtail-auth.yaml
+++ b/secrets/promtail/promtail-auth.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-data:
+stringData:
     PROMTAIL_PASSWORD: ENC[AES256_GCM,data:ik0IWtdk8Wp2h1hmNXBSOV7F5W870WKAG05WeIuLyInCWaRsFPbcUVBI0VY2BuiEGfSizYzzCnScaNqujyHXbpkrG6yd8tOtPuQMSdQAoOYyS3qzB2D426vrTe/S6mkt4FACiYFJx3s/MZ2K3YaILs9nBn4d0XgYD86OUgD4q4ncukOdAstuTPcfKmsEkw8h,iv:NPTNn4xzuwJsvwEGZTtJAeMfnGimzSniE2k/JEiAAAE=,tag:uz9yVHye2qkNMBcnRhw3ZQ==,type:str]
     PROMTAIL_USERNAME: ENC[AES256_GCM,data:gQQZRFmdSqI=,iv:/TPcSnxKzKbvjlLmsi8+vuXN0nnXpjaSUbfeefqrdu8=,tag:4tGjn4owNRe7VrS1k7OGrQ==,type:str]
 kind: Secret


### PR DESCRIPTION
The promtail-secrets KS is complaining: `Secret/flux-system/promtail-auth forbidden, error: data values must be of type string`
This seems to have started after upgrading fileinfra to flux version v0.34.0.  
This PR changes the secret data from `data:` to `stringData`