### PR TITLE
Fixing go templating that was not concatenating the thanos hostname 

### DIFF
--- a/charts/template-filecoin-infra/Chart.yaml
+++ b/charts/template-filecoin-infra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: template-filecoin-infra
 description: A Weaveworks Helm chart for template-filecoin-infra
 type: application
-version: 0.0.10
+version: 0.0.11
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/weaveworks/profiles-catalog
 sources:

--- a/charts/template-filecoin-infra/Chart.yaml
+++ b/charts/template-filecoin-infra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: template-filecoin-infra
 description: A Weaveworks Helm chart for template-filecoin-infra
 type: application
-version: 0.0.11
+version: 0.0.12
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/weaveworks/profiles-catalog
 sources:

--- a/charts/template-filecoin-infra/values.yaml
+++ b/charts/template-filecoin-infra/values.yaml
@@ -133,11 +133,11 @@ template-base:
     \      eks.amazonaws.com/role-arn: arn:aws:iam::{{ template \"template-base.accountIDAnnotation\" . }}:role/{{`{{ .params.CLUSTER_NAME }}`}}-monitoring\\n
     \  thanosIngress:\\n
     \    hosts:\\n
-    \    - thanos.{{`{{ .params.CLUSTER_NAME }}`}}s.{{`{{ .params.TEAM }}`}}.{{`{{ .params.AWS_ACCOUNT_NAME }}`}}.w3ops.net\\n
+    \    - thanos.{{`{{ printf "%.*s" 22 .params.CLUSTER_NAME }}`}}s.{{`{{ .params.TEAM }}`}}.{{`{{ .params.AWS_ACCOUNT_NAME }}`}}.w3ops.net\\n
     \    tls:\\n
     \    - secretName: thanos-sidecar-tls\\n
     \      hosts:\\n
-    \      - thanos.{{`{{ .params.CLUSTER_NAME }}`}}s.{{`{{ .params.TEAM }}`}}.{{`{{ .params.AWS_ACCOUNT_NAME }}`}}.w3ops.net\\n
+    \      - thanos.{{`{{ printf "%.*s" 22 .params.CLUSTER_NAME }}`}}s.{{`{{ .params.TEAM }}`}}.{{`{{ .params.AWS_ACCOUNT_NAME }}`}}.w3ops.net\\n
     thanos:\\n
     \ compactor:\\n
     \  serviceAccount:\\n

--- a/charts/template-filecoin-infra/values.yaml
+++ b/charts/template-filecoin-infra/values.yaml
@@ -133,11 +133,11 @@ template-base:
     \      eks.amazonaws.com/role-arn: arn:aws:iam::{{ template \"template-base.accountIDAnnotation\" . }}:role/{{`{{ .params.CLUSTER_NAME }}`}}-monitoring\\n
     \  thanosIngress:\\n
     \    hosts:\\n
-    \    - thanos.{{`{{ printf "%.*s" 22 .params.CLUSTER_NAME }}`}}s.{{`{{ .params.TEAM }}`}}.{{`{{ .params.AWS_ACCOUNT_NAME }}`}}.w3ops.net\\n
+    \    - thanos.{{ printf \"%.*s\" 22 `{{ .params.CLUSTER_NAME }}`}}s.{{`{{ .params.TEAM }}`}}.{{`{{ .params.AWS_ACCOUNT_NAME }}`}}.w3ops.net\\n
     \    tls:\\n
     \    - secretName: thanos-sidecar-tls\\n
     \      hosts:\\n
-    \      - thanos.{{`{{ printf "%.*s" 22 .params.CLUSTER_NAME }}`}}s.{{`{{ .params.TEAM }}`}}.{{`{{ .params.AWS_ACCOUNT_NAME }}`}}.w3ops.net\\n
+    \      - thanos.{{`{{ printf \"%.*s\" 22 .params.CLUSTER_NAME }}`}}s.{{`{{ .params.TEAM }}`}}.{{`{{ .params.AWS_ACCOUNT_NAME }}`}}.w3ops.net\\n
     thanos:\\n
     \ compactor:\\n
     \  serviceAccount:\\n

--- a/charts/template-generic/Chart.yaml
+++ b/charts/template-generic/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: template-generic
 description: A Weaveworks Helm chart for template-generic
 type: application
-version: 0.4.3
+version: 0.4.4
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/weaveworks/profiles-catalog
 sources:

--- a/charts/template-generic/Chart.yaml
+++ b/charts/template-generic/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: template-generic
 description: A Weaveworks Helm chart for template-generic
 type: application
-version: 0.4.4
+version: 0.4.5
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/weaveworks/profiles-catalog
 sources:

--- a/charts/template-generic/values.yaml
+++ b/charts/template-generic/values.yaml
@@ -133,11 +133,11 @@ template-base:
     \      eks.amazonaws.com/role-arn: arn:aws:iam::{{ template \"template-base.accountIDAnnotation\" . }}:role/{{`{{ .params.CLUSTER_NAME }}`}}-monitoring\\n
     \  thanosIngress:\\n
     \    hosts:\\n
-    \    - thanos.{{`{{ .params.CLUSTER_NAME }}`}}s.{{`{{ .params.TEAM }}`}}.{{`{{ .params.AWS_ACCOUNT_NAME }}`}}.w3ops.net\\n
+    \    - thanos.{{`{{ printf "%.*s" 22 .params.CLUSTER_NAME }}`}}s.{{`{{ .params.TEAM }}`}}.{{`{{ .params.AWS_ACCOUNT_NAME }}`}}.w3ops.net\\n
     \    tls:\\n
     \    - secretName: thanos-sidecar-tls\\n
     \      hosts:\\n
-    \      - thanos.{{`{{ .params.CLUSTER_NAME }}`}}s.{{`{{ .params.TEAM }}`}}.{{`{{ .params.AWS_ACCOUNT_NAME }}`}}.w3ops.net\\n
+    \      - thanos.{{`{{ printf "%.*s" 22 .params.CLUSTER_NAME }}`}}s.{{`{{ .params.TEAM }}`}}.{{`{{ .params.AWS_ACCOUNT_NAME }}`}}.w3ops.net\\n
     thanos:\\n
     \ compactor:\\n
     \  serviceAccount:\\n

--- a/charts/template-generic/values.yaml
+++ b/charts/template-generic/values.yaml
@@ -133,11 +133,11 @@ template-base:
     \      eks.amazonaws.com/role-arn: arn:aws:iam::{{ template \"template-base.accountIDAnnotation\" . }}:role/{{`{{ .params.CLUSTER_NAME }}`}}-monitoring\\n
     \  thanosIngress:\\n
     \    hosts:\\n
-    \    - thanos.{{`{{ printf "%.*s" 22 .params.CLUSTER_NAME }}`}}s.{{`{{ .params.TEAM }}`}}.{{`{{ .params.AWS_ACCOUNT_NAME }}`}}.w3ops.net\\n
+    \    - thanos.{{`{{ printf \"%.*s\" 22 .params.CLUSTER_NAME }}`}}s.{{`{{ .params.TEAM }}`}}.{{`{{ .params.AWS_ACCOUNT_NAME }}`}}.w3ops.net\\n
     \    tls:\\n
     \    - secretName: thanos-sidecar-tls\\n
     \      hosts:\\n
-    \      - thanos.{{`{{ printf "%.*s" 22 .params.CLUSTER_NAME }}`}}s.{{`{{ .params.TEAM }}`}}.{{`{{ .params.AWS_ACCOUNT_NAME }}`}}.w3ops.net\\n
+    \      - thanos.{{`{{ printf \"%.*s\" 22 .params.CLUSTER_NAME }}`}}s.{{`{{ .params.TEAM }}`}}.{{`{{ .params.AWS_ACCOUNT_NAME }}`}}.w3ops.net\\n
     thanos:\\n
     \ compactor:\\n
     \  serviceAccount:\\n

--- a/charts/template-sentinel/Chart.yaml
+++ b/charts/template-sentinel/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: template-sentinel
 description: A Weaveworks Helm chart for template-sentinel
 type: application
-version: 0.4.5
+version: 0.4.6
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/weaveworks/profiles-catalog
 sources:

--- a/charts/template-sentinel/Chart.yaml
+++ b/charts/template-sentinel/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: template-sentinel
 description: A Weaveworks Helm chart for template-sentinel
 type: application
-version: 0.4.6
+version: 0.4.7
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/weaveworks/profiles-catalog
 sources:

--- a/charts/template-sentinel/values.yaml
+++ b/charts/template-sentinel/values.yaml
@@ -113,11 +113,11 @@ template-base:
     \      eks.amazonaws.com/role-arn: arn:aws:iam::{{ template \"template-base.accountIDAnnotation\" . }}:role/{{`{{ .params.CLUSTER_NAME }}`}}-monitoring\\n
     \  thanosIngress:\\n
     \    hosts:\\n
-    \    - thanos.{{`{{ printf "%.*s" 22 .params.CLUSTER_NAME }}`}}s.{{`{{ .params.TEAM }}`}}.{{`{{ .params.AWS_ACCOUNT_NAME }}`}}.w3ops.net\\n
+    \    - thanos.{{`{{ printf \"%.*s\" 22 .params.CLUSTER_NAME }}`}}s.{{`{{ .params.TEAM }}`}}.{{`{{ .params.AWS_ACCOUNT_NAME }}`}}.w3ops.net\\n
     \    tls:\\n
     \    - secretName: thanos-sidecar-tls\\n
     \      hosts:\\n
-    \      - thanos.{{`{{ printf "%.*s" 22 .params.CLUSTER_NAME }}`}}s.{{`{{ .params.TEAM }}`}}.{{`{{ .params.AWS_ACCOUNT_NAME }}`}}.w3ops.net\\n
+    \      - thanos.{{`{{ printf \"%.*s\" 22 .params.CLUSTER_NAME }}`}}s.{{`{{ .params.TEAM }}`}}.{{`{{ .params.AWS_ACCOUNT_NAME }}`}}.w3ops.net\\n
     thanos:\\n
     \ compactor:\\n
     \  serviceAccount:\\n

--- a/charts/template-sentinel/values.yaml
+++ b/charts/template-sentinel/values.yaml
@@ -113,11 +113,11 @@ template-base:
     \      eks.amazonaws.com/role-arn: arn:aws:iam::{{ template \"template-base.accountIDAnnotation\" . }}:role/{{`{{ .params.CLUSTER_NAME }}`}}-monitoring\\n
     \  thanosIngress:\\n
     \    hosts:\\n
-    \    - thanos.{{`{{ .params.CLUSTER_NAME }}`}}s.{{`{{ .params.TEAM }}`}}.{{`{{ .params.AWS_ACCOUNT_NAME }}`}}.w3ops.net\\n
+    \    - thanos.{{`{{ printf "%.*s" 22 .params.CLUSTER_NAME }}`}}s.{{`{{ .params.TEAM }}`}}.{{`{{ .params.AWS_ACCOUNT_NAME }}`}}.w3ops.net\\n
     \    tls:\\n
     \    - secretName: thanos-sidecar-tls\\n
     \      hosts:\\n
-    \      - thanos.{{`{{ .params.CLUSTER_NAME }}`}}s.{{`{{ .params.TEAM }}`}}.{{`{{ .params.AWS_ACCOUNT_NAME }}`}}.w3ops.net\\n
+    \      - thanos.{{`{{ printf "%.*s" 22 .params.CLUSTER_NAME }}`}}s.{{`{{ .params.TEAM }}`}}.{{`{{ .params.AWS_ACCOUNT_NAME }}`}}.w3ops.net\\n
     thanos:\\n
     \ compactor:\\n
     \  serviceAccount:\\n


### PR DESCRIPTION
The new helm template migration missed concatenating the thanos hostname correctly to match the ingress on the leaf cluster.