### PR TITLE
chore(sentinel): Update github token

### DIFF
--- a/secrets/sentinel/sentinel-github-token.yaml
+++ b/secrets/sentinel/sentinel-github-token.yaml
@@ -1,41 +1,40 @@
 apiVersion: v1
 data:
-    password: ENC[AES256_GCM,data:1xg1X47YHUpPFufgTquhw9dh0lWxfvrCNQqyCw4vCsnyg35U93D/+p8gAV0NETKD7APAetvnvSQ=,iv:fKU85fDQNW7rC1qvTcR1nUEepElgGwLANB045x7DXQA=,tag:GsNV9hAKanX07xkK4vCHuQ==,type:str]
-    username: ENC[AES256_GCM,data:TZXZB/YtIKnAFtJVxB/rdw==,iv:REcV+klpH4A0R2/SsXBHaEPPvy7LFaFQWMKp+769s78=,tag:mbr2/1bXB5rZhwGljMv9uQ==,type:str]
+    password: ENC[AES256_GCM,data:z/nQwW8aZ+3mz/s9cq+Szi4E77NK9r2/mZN77HrQfHq9E6nKQHjido43PBGXvL3bPjimuNQmJwU=,iv:utt3zovfLR3z7HJeODcwOQblG0zMcYEBGToh9nn0W1s=,tag:RzYqu9Zs+RFDR6tzh18pAQ==,type:str]
+    username: ENC[AES256_GCM,data:zM9PUjAp7F5MSART,iv:Ol/yMQ4LlnSlAqDPCWcUFaeTITPsgWDF199rE8GBA1Y=,tag:AqfuTJq5crn9PQKCr/bSlQ==,type:str]
 kind: Secret
 metadata:
     creationTimestamp: null
     name: sentinel-github-token
-    namespace: flux-system
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2022-06-06T20:31:25Z"
-    mac: ENC[AES256_GCM,data:Chi3RQ5QTb+OFWYfg/aB0G1ora8WqZ4xWVyOKouh17jLIH/duFfUqJb3reJg+x/JuPQUqSJ3/q9uGuHrTys24wsOfQXtiIFP45nJQKg4SDNjKSKE38m/GT0K6Q+a+euJy6sB8YjaWbKdNOHY58ESE9z4Sed4byW782z4hCjX3go=,iv:zIaPDsugpdpdrRMeUOBv6cjkDoefn5103SexN6oWBSI=,tag:5xogS+YXzbC/rUtMbHF4ow==,type:str]
+    lastmodified: "2022-10-07T23:09:43Z"
+    mac: ENC[AES256_GCM,data:UnkfC+Qa1YbGWmhYgdEzjp0eW7Mq+ryZdBnsZ7TRS8n6khm/zwgcRe+pzD1JBOaAxpuhjUrFXlGhNQdCXBo1umWeYehIsmm72JxPsEj+5aSX7GMFiOsBPbmAGA0XGQDrkeudnVQMXKddQn1m6vGOWXWYPy/YLo2gBF1ikco77T4=,iv:KKrd5AhY+0I04VGWHtpaW/2lvZET9/sr2yph+hw0hZE=,tag:B/hXvb0oU6TMwipr4n5VOg==,type:str]
     pgp:
-        - created_at: "2022-06-06T20:31:24Z"
+        - created_at: "2022-10-07T23:09:42Z"
           enc: |
             -----BEGIN PGP MESSAGE-----
 
-            hQIMA2IWPpjKSDN/AQ//XLpw/ZY1RUAFDMJT9J9JKhuUXVv/yMLCDXiVyTVOoLE+
-            0Un5Hgnn5U6nAR47fIjgmv/wQFqeoOSo/zQOHlDt0kUreTniLKpXJwSPGZZNANkV
-            r1r/4aZWjol7LSdep3Ytnu/+jK4/RCzwXk0OYt5Y181oIuCbt5cHZYt13dTIlfbq
-            wICJJd7OpImqHq7HSqDMuBRg/hyBGsb09SOf/BWt0/Da5NA5mIsstxvUZBKUom0W
-            W/tkShA/6WbhPuuDYlFVcAWOOHXFMMbBfWv18l1qycbHeXYzqwtCl3dfQ5dVoEgt
-            stbzVeqOOHjm2rT9/L0WzXVAbZtIVpgipTN6D9rThsGuv+KCw1SNHXxQy8v6r0Mc
-            BpTHKGhAXwWxdoBL0/RswxU/DF7AwCNmEkZZrI5kr9mQAjG7ljEQPUNFxi/Fvu2J
-            zwQ6ubzYJXUoZqmWRbRAS9aQ+QMqNPT0UfuJyd+vTGaA6lJsOBWFjlzVDirbzjiY
-            blc75ogkt9KkQ++dVCFX+JWtYoktBUyQY3A8P4sLNmE1wfwRJv5A/b8bqkKMGrVu
-            h817yXgwIaXoBrmIswGeupaSJD/wZC2xUm2js1euq15RI/9+EuPT8oM9hb4b1CZO
-            g2Qf0ngtyH6bXwzMl2c75dOwCEavHFy/r4j7098RlQz/aKRzai8zAcppBLOtyy/U
-            aAEJAhB48CMglVHe999wMYlPgy99y90o7/AtXv6+78krdyAvN8OZSwl0FC0mlffZ
-            xyOdKppx1nqKsZQfku8+ggKJqT4kYxGLo+Dn/sqGtZuZmqtUetPZ9hO0Z7sOloFz
-            NOQMbrIRHndz
-            =FC0M
+            hQIMA2IWPpjKSDN/ARAAlZHRQSBujbLGcXAIK/q3o/gqGif7oFavBW5Q0CwDJDfr
+            dgO86DtIIcja2eQN8E3QGi+VHMc3FuE00JbCA/Aqni4PREGyQWuhCgcWXFWmA/DM
+            AxuyYryLruwe9WMW4cu2P/kknavdYrCEY3f5Uf6j38smJXOI4PXchQSn/a20980k
+            Ta7Px3Xzn4aM0z2EQIx5mELkVe9WfLDnLaJrkPE7F46SodfvGlBPhOPdRnO8TDYX
+            /16WZf7Lj/r93EidRazoK9tsvmvqxIh9lJCPeTWgqoIHsNF701332zEDGwZLoA7d
+            tUJNVNfvlZq0bdsDJ6JCuKrFNz/rofPOJFNkGktqjH9m8w9MDdrikNWYmt5ETI1A
+            aU5gOekbCnM6lZ0Hpg35X2nbmHquLZyezbof1zVkzLh3iUk7v7+O+3xa5Aj8iYwK
+            +w2tXZu0zjnA+qd6vnOfvEBErfSJWKMhhhOi9IH6A0reFy+yjWVobzykC6RM5my0
+            XM/ogdou58RmxFiQ6QNrUpFOi1EJRKTVUVbx9wDxvXh+RiQJCUs+3vapVykWZenv
+            0Bt0MJ6x0VVDdmusljrGWt8FhKFQSBpb/x+tS4ofSoLnMvX7YIA7IfPQunnhWYNd
+            Zh0oHdZ9QQ+ndSB/rvpXaj0jqZ4vKuWV2LKCfkY13UkttaKZ2sAppGdf1BBGq9LU
+            ZgEJAhD8vs5r+hOFJJbi4pm+6soDtBo3+XgWGlXtZgIdfG/a3aQF+YZAtNPWeFAD
+            TmVSKqXweirx+t0yb+8CxnJaPqf/jDH0kiwUI82l8jCV7iDlaiORHmkaPuesRjGb
+            VcjTrBOr5g==
+            =9lyF
             -----END PGP MESSAGE-----
           fp: 3C778F802D79787BCE9D795CE20F63D488FC275F
     encrypted_regex: ^(data|stringData)$
-    version: 3.7.1
+    version: 3.7.3


### PR DESCRIPTION
The existing token was tied to permissions which are now disabled. This is a temporary token attached to my personal account [until we can get the PL GitOps bot to take ownership of this](https://github.com/filecoin-project/sentinel-infra/issues/340).