### PR TITLE
Update the Cluster Node Group 0 with r5.2xlarge

### DIFF
--- a/charts/template-filecoin-infra/Chart.yaml
+++ b/charts/template-filecoin-infra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: template-filecoin-infra
 description: A Weaveworks Helm chart for template-filecoin-infra
 type: application
-version: 0.0.19
+version: 0.0.20
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/weaveworks/profiles-catalog
 sources:

--- a/charts/template-filecoin-infra/values.yaml
+++ b/charts/template-filecoin-infra/values.yaml
@@ -24,8 +24,8 @@ template-base:
     minOptions: ["1"]
     availabilityZones: ["a", "b", "c"]
     instanceTypeOptions:
-    - "r5.8xlarge"
-  - name: 1
+    - "r5.2xlarge"
+ - name: 1
     type: MachineDeployment   # Only MachineDeployment supported today (Pending MachinePool)
     maxOptions: ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "15", "25", "30"]
     minOptions: ["0", "1"]

--- a/charts/template-filecoin-infra/values.yaml
+++ b/charts/template-filecoin-infra/values.yaml
@@ -25,7 +25,7 @@ template-base:
     availabilityZones: ["a", "b", "c"]
     instanceTypeOptions:
     - "r5.2xlarge"
- - name: 1
+  - name: 1
     type: MachineDeployment   # Only MachineDeployment supported today (Pending MachinePool)
     maxOptions: ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "15", "25", "30"]
     minOptions: ["0", "1"]


### PR DESCRIPTION
Updated the Node Group 0 to run "r.5.2xlarge" worker nodes. This is with regards to the issue 
https://app.zenhub.com/workspaces/filecoin-infra-5f4d86681da5a149e7684477/issues/filecoin-project/lotus-infra/882