### PR TITLE
machineDeployment: added the instaceType to the name of awsmachineTem…

### DIFF
--- a/charts/template-base/Chart.yaml
+++ b/charts/template-base/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: template-base
 description: A Weaveworks Helm chart for template
 type: application
-version: 0.5.10
+version: 0.5.11
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/weaveworks/profiles-catalog
 

--- a/charts/template-base/files/machinedeployment.yaml
+++ b/charts/template-base/files/machinedeployment.yaml
@@ -3,7 +3,9 @@
 - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
   kind: AWSMachineTemplate
   metadata:
-    name: '{{`{{ .params.CLUSTER_NAME }}`}}-machine-deployment-{{ $nodeGroup.name }}-0'
+    name: '{{`{{ .params.CLUSTER_NAME }}`}}-{{`{{ .params.INSTANCE_TYPE_NODEGROUP_`}}{{ $nodeGroup.name }} }}-machine-deployment-{{ $nodeGroup.name }}-0'
+    annotations:
+      kustomize.toolkit.fluxcd.io/prune: disabled
   spec:
     template:
       spec:
@@ -46,7 +48,7 @@
             apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
             kind: EKSConfigTemplate
         infrastructureRef:
-          name: '{{`{{ .params.CLUSTER_NAME }}`}}-machine-deployment-{{ $nodeGroup.name }}-0'
+          name: '{{`{{ .params.CLUSTER_NAME }}`}}-{{`{{ .params.INSTANCE_TYPE_NODEGROUP_`}}{{ $nodeGroup.name }} }}-machine-deployment-{{ $nodeGroup.name }}-0'
           apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
           kind: AWSMachineTemplate
 {{- end }}

--- a/charts/template-filecoin-infra/Chart.yaml
+++ b/charts/template-filecoin-infra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: template-filecoin-infra
 description: A Weaveworks Helm chart for template-filecoin-infra
 type: application
-version: 0.0.21
+version: 0.0.22
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/weaveworks/profiles-catalog
 sources:
@@ -17,5 +17,5 @@ maintainers:
 
 dependencies:
 - name: template-base
-  version: "0.5.10"
+  version: "0.5.11"
   repository: "file://../template-base"


### PR DESCRIPTION
…plate and machineDeployment so that CAPA will see that there is a change in the instancetype.  
NOTE: currently the awsMachineTemplate is an immutable field, this resolves that issue by adding any change to the instanceType to the name so that a new awsMachineType is deployed.  
NOTENOTE: the old awsMachineTemplate needs to persist until after the new AwsMachineTemplate is done instantiating before it can be deleted. This is a bug in CAPA