### PR TITLE
Update release-metrics-exporters chart

### DIFF
--- a/charts/release-metrics-exporters/Chart.yaml
+++ b/charts/release-metrics-exporters/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: release-metrics-exporters
 description: A suite of Prometheus Exporters to caputre release metrics from github, docker hub, homebrew, and snapcraft.
 type: application
-version: "0.0.6"
+version: "0.1.0"
 appVersion: "0.0.0"
 
 annotations:

--- a/charts/release-metrics-exporters/templates/deployment-github.yaml
+++ b/charts/release-metrics-exporters/templates/deployment-github.yaml
@@ -39,5 +39,5 @@ spec:
           valueFrom:
             secretKeyRef:
               name: github
-              key: token
+              key: GITHUB_TOKEN
               optional: true

--- a/charts/release-metrics-exporters/templates/service-monitor-dockerhub.yaml
+++ b/charts/release-metrics-exporters/templates/service-monitor-dockerhub.yaml
@@ -6,7 +6,7 @@ metadata:
     serviceMonitorSelector: dockerhub-exporter
 spec:
   endpoints:
-  - interval: 10m
+  - interval: {{ .Values.dockerhub.interval }}
     port: metrics
     path: {{ .Values.dockerhub.metricsPath }}
   namespaceSelector:

--- a/charts/release-metrics-exporters/templates/service-monitor-github.yaml
+++ b/charts/release-metrics-exporters/templates/service-monitor-github.yaml
@@ -6,7 +6,7 @@ metadata:
     serviceMonitorSelector: github-exporter
 spec:
   endpoints:
-  - interval: 10m
+  - interval: {{ .Values.github.interval }}
     port: metrics
     path: {{ .Values.github.metricsPath }}
   namespaceSelector:

--- a/charts/release-metrics-exporters/templates/service-monitor-homebrew.yaml
+++ b/charts/release-metrics-exporters/templates/service-monitor-homebrew.yaml
@@ -6,7 +6,7 @@ metadata:
     serviceMonitorSelector: homebrew-exporter
 spec:
   endpoints:
-  - interval: 10m
+  - interval: {{ .Values.homebrew.interval }}
     port: metrics
     path: {{ .Values.homebrew.metricsPath }}
   namespaceSelector:

--- a/charts/release-metrics-exporters/templates/service-monitor-snapcraft.yaml
+++ b/charts/release-metrics-exporters/templates/service-monitor-snapcraft.yaml
@@ -6,7 +6,7 @@ metadata:
     serviceMonitorSelector: snapcraft-exporter
 spec:
   endpoints:
-  - interval: 10m
+  - interval: {{ .Values.snapcraft.interval }}
     scrapeTimeout: 5m
     port: metrics
     path: {{ .Values.snapcraft.metricsPath }}

--- a/charts/release-metrics-exporters/values.yaml
+++ b/charts/release-metrics-exporters/values.yaml
@@ -1,4 +1,5 @@
 github:
+  interval : 10m
   listenPort: 9888
   metricsPath: /metrics
   repos:
@@ -8,6 +9,7 @@ github:
   users:
   - ""
 dockerhub:
+  interval : 10m
   listenPort: 9888
   metricsPath: /metrics
   images:
@@ -15,11 +17,13 @@ dockerhub:
   orgs:
   - ""
 homebrew:
+  interval : 10m
   listenPort: 9888
   metricsPath: /metrics
   formulae:
   - ""
 snapcraft:
+  interval : 10m
   listenPort: 9888
   metricsPath: /metrics
   names:


### PR DESCRIPTION
- Changes name of GITHUB_TOKEN secret
- Makes interval easier to configure by putting it in the values