### PR TITLE
Add circleci and bump scrapeTimeout up on relevant release exporters

### DIFF
--- a/charts/release-metrics-exporters/Chart.yaml
+++ b/charts/release-metrics-exporters/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: release-metrics-exporters
 description: A suite of Prometheus Exporters to caputre release metrics from github, docker hub, homebrew, and snapcraft.
 type: application
-version: "0.1.1"
+version: "0.1.2"
 appVersion: "0.0.0"
 
 annotations:

--- a/charts/release-metrics-exporters/Chart.yaml
+++ b/charts/release-metrics-exporters/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: release-metrics-exporters
 description: A suite of Prometheus Exporters to caputre release metrics from github, docker hub, homebrew, and snapcraft.
 type: application
-version: "0.1.0"
+version: "0.1.1"
 appVersion: "0.0.0"
 
 annotations:

--- a/charts/release-metrics-exporters/templates/deployment-circleci.yaml
+++ b/charts/release-metrics-exporters/templates/deployment-circleci.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: circleci-exporter
+  labels:
+    app: circleci-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: circleci-exporter
+  template:
+    metadata:
+      labels:
+        app: circleci-exporter
+    spec:
+      containers:
+      - name: circleci-exporter
+        image: ianconsolata/circleci-exporter:latest
+        imagePullPolicy: Always
+        command: ["/bin/circleci-exporter"]
+        args:
+        - --web.telemetry-path={{ .Values.circleci.metricsPath }}
+        - --web.listen-address=":{{ .Values.circleci.listenPort }}"
+        - --gh.circleci-org="{{ .Values.circleci.org }}"
+        - --gh.circleci-vsc-slug="{{ .Values.circleci.vsc }}"
+        {{- range .Values.circleci.projects }}
+        - --gh.circleci-projects="{{ . }}"
+        {{- end}}
+        - --gh.circleci-token="CIRCLECI_TOKEN"
+        ports:
+        - containerPort: {{ .Values.circleci.listenPort }}
+        env:
+        - name: CIRCLECI_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: circleci
+              key: CIRCLECI_TOKEN
+              optional: true

--- a/charts/release-metrics-exporters/templates/service-circleci.yaml
+++ b/charts/release-metrics-exporters/templates/service-circleci.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: circleci-exporter
+  labels:
+    app: circleci-exporter
+spec:
+  ports:
+  - port: 9888
+    targetPort: {{ .Values.circleci.listenPort}}
+    name: metrics
+  selector:
+    app: circleci-exporter

--- a/charts/release-metrics-exporters/templates/service-monitor-circleci.yaml
+++ b/charts/release-metrics-exporters/templates/service-monitor-circleci.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: circleci-exporter
+  labels:
+    serviceMonitorSelector: circleci-exporter
+spec:
+  endpoints:
+  - interval: {{ .Values.circleci.interval }}
+    # TODO: This is a horrible hack to allow us to scrape many projects with one exporter,
+    # a better solution is to deploy one exporter per project.
+    scrapeTimeout: {{ .Values.circleci.interval }}
+    port: metrics
+    path: {{ .Values.circleci.metricsPath }}
+  namespaceSelector:
+    any: true
+  selector:
+    matchLabels:
+      app: circleci-exporter

--- a/charts/release-metrics-exporters/templates/service-monitor-dockerhub.yaml
+++ b/charts/release-metrics-exporters/templates/service-monitor-dockerhub.yaml
@@ -7,6 +7,9 @@ metadata:
 spec:
   endpoints:
   - interval: {{ .Values.dockerhub.interval }}
+    # TODO: This is a horrible hack to allow us to scrape many projects with one exporter,
+    # a better solution is to deploy one exporter per project.
+    scrapeTimeout: {{ .Values.dockerhub.interval }}
     port: metrics
     path: {{ .Values.dockerhub.metricsPath }}
   namespaceSelector:

--- a/charts/release-metrics-exporters/templates/service-monitor-github.yaml
+++ b/charts/release-metrics-exporters/templates/service-monitor-github.yaml
@@ -7,6 +7,9 @@ metadata:
 spec:
   endpoints:
   - interval: {{ .Values.github.interval }}
+    # TODO: This is a horrible hack to allow us to scrape many projects with one exporter,
+    # a better solution is to deploy one exporter per project.
+    scrapeTimeout: {{ .Values.github.interval }}
     port: metrics
     path: {{ .Values.github.metricsPath }}
   namespaceSelector:

--- a/charts/release-metrics-exporters/templates/service-monitor-homebrew.yaml
+++ b/charts/release-metrics-exporters/templates/service-monitor-homebrew.yaml
@@ -7,6 +7,8 @@ metadata:
 spec:
   endpoints:
   - interval: {{ .Values.homebrew.interval }}
+    # Unlike the other exporters, homebrew makes a constant number of request then pulls all projects out of that request,
+    # so it can scale to many projects with a single exporter and no scrapeTimeout is needed
     port: metrics
     path: {{ .Values.homebrew.metricsPath }}
   namespaceSelector:

--- a/charts/release-metrics-exporters/templates/service-monitor-snapcraft.yaml
+++ b/charts/release-metrics-exporters/templates/service-monitor-snapcraft.yaml
@@ -7,7 +7,9 @@ metadata:
 spec:
   endpoints:
   - interval: {{ .Values.snapcraft.interval }}
-    scrapeTimeout: 5m
+    # TODO: This is a horrible hack to allow us to scrape many projects with one exporter,
+    # a better solution is to deploy one exporter per project.
+    scrapeTimeout: {{ .Values.snapcraft.interval }}
     port: metrics
     path: {{ .Values.snapcraft.metricsPath }}
   namespaceSelector:

--- a/charts/release-metrics-exporters/values.yaml
+++ b/charts/release-metrics-exporters/values.yaml
@@ -1,5 +1,5 @@
 github:
-  interval : 10m
+  interval: 10m
   listenPort: 9888
   metricsPath: /metrics
   repos:
@@ -9,7 +9,7 @@ github:
   users:
   - ""
 dockerhub:
-  interval : 10m
+  interval: 10m
   listenPort: 9888
   metricsPath: /metrics
   images:
@@ -17,14 +17,22 @@ dockerhub:
   orgs:
   - ""
 homebrew:
-  interval : 10m
+  interval: 10m
   listenPort: 9888
   metricsPath: /metrics
   formulae:
   - ""
 snapcraft:
-  interval : 10m
+  interval: 10m
   listenPort: 9888
   metricsPath: /metrics
   names:
   - ""
+circleci:
+  interval: 10m
+  listenPort: 9888
+  metricsPath: /metrics
+  projects:
+  - ""
+  org: ""
+  vcs: github     # github, bitbucket


### PR DESCRIPTION
This adds a CircleCI metrics exporter, as well as bumping the timeout on all the metrics exporters except homebrew (which makes a constant number of requests no matter how many projects it is looking for).

The default scrape timeout for prometheus is 10s. Since we don't scrape nearly that often, this bumps up the timeout to match the interval. As long as the scrape returns in less time than the interval now, it will still work, and the interval can be configured from the values.

This is a hacky solution to allow us to grab metrics for multiple projects with a single metrics exporter. We encountered this issue because we added a new project to the github exporter, which took it over the timeout limit.

A much more scalable solution would be to create separate exporters for each project, or batch the projects intelligently into groups so each exporter still returns quickly. Until then, this solution should work.