### PR TITLE
Remove provisioner from storageclass

### DIFF
--- a/charts/aws-ebs-csi-driver/CHANGELOG.md
+++ b/charts/aws-ebs-csi-driver/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.0.5
+Fix duplicate "provisioner" field introduced in 0.0.4
+
+## 0.0.4 [BROKEN]
+*Please skip to 0.0.5*
+- Adds gp3 storageclasses and volumesnapshotclasses

--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -3,7 +3,7 @@ name: aws-ebs-csi-driver
 icon: https://raw.githubusercontent.com/aws-ebs-csi-driver/aws-ebs-csi-driver.github.io/master/assets/aws-ebs-csi-driver_logo-cb55bb5c346.png
 description: A Weaveworks Helm chart for the aws ebs csi driver
 type: application
-version: 0.0.4
+version: 0.0.5
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/weaveworks/profiles-catalog
 sources:

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -8,14 +8,12 @@ aws-ebs-csi-driver:
   - name: gp3
     annotations:
       storageclass.kubernetes.io/is-default-class: "true"
-    provisioner: ebs.csi.aws.com
     volumeBindingMode: WaitForFirstConsumer
     reclaimPolicy: Delete
     allowVolumeExpansion: true
   - name: gp3-retain
     annotations:
       storageclass.kubernetes.io/is-default-class: "false"
-    provisioner: ebs.csi.aws.com
     volumeBindingMode: WaitForFirstConsumer
     reclaimPolicy: Retain
     allowVolumeExpansion: true


### PR DESCRIPTION
This doesn't seem to be a problem when running helm locally, but it
choked flux due to introducing a duplicate field
